### PR TITLE
Increase read timeouts

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -28,6 +28,8 @@ http {
 
     location / {
       proxy_pass  https://backend_prod;
+      proxy_read_timeout 300;
+      send_timeout 300;
       proxy_set_header Host www1.agenciatributaria.gob.es;
       proxy_ssl_certificate /etc/nginx/ssl/aeat.crt;
       proxy_ssl_certificate_key /etc/nginx/ssl/aeat.key;
@@ -35,6 +37,8 @@ http {
 
     location /test/ {
       proxy_pass  https://backend_test/;
+      proxy_read_timeout 300;
+      send_timeout 300;
       proxy_set_header Host www7.aeat.es;
       proxy_ssl_certificate /etc/nginx/ssl/aeat.crt;
       proxy_ssl_certificate_key /etc/nginx/ssl/aeat.key;
@@ -42,6 +46,8 @@ http {
 
     location /nifs/ {
       proxy_pass  https://backend_nifs/;
+      proxy_read_timeout 300;
+      send_timeout 300;
       proxy_set_header Host www1.agenciatributaria.gob.es;
       proxy_ssl_certificate /etc/nginx/ssl/aeat.crt;
       proxy_ssl_certificate_key /etc/nginx/ssl/aeat.key;

--- a/nginx.conf
+++ b/nginx.conf
@@ -46,8 +46,6 @@ http {
 
     location /nifs/ {
       proxy_pass  https://backend_nifs/;
-      proxy_read_timeout 300;
-      send_timeout 300;
       proxy_set_header Host www1.agenciatributaria.gob.es;
       proxy_ssl_certificate /etc/nginx/ssl/aeat.crt;
       proxy_ssl_certificate_key /etc/nginx/ssl/aeat.key;


### PR DESCRIPTION
Sometimes when doing connections related to SII the nginx returns:

```html
Server returned HTTP status 504 (<html>
<head><title>504 Gateway Time-out</title></head>
<body bgcolor="white">
<center><h1>504 Gateway Time-out</h1></center>
<hr><center>nginx/1.10.0 (Ubuntu)</center>
</body>
</html>
)
```
And the nginx log is:

```bash
2017/11/26 21:01:01 [error] 1439#1439: *260289 upstream timed out (110: Connection timed out) while reading response header from upstream, client: 192.168.32.23, server: , request: "POST /wlpl/SSII-FACT/ws/fr/SiiFactFRV1SOAP HTTP/1.1", upstream: "https://195.235.106.208:443/wlpl/SSII-FACT/ws/fr/SiiFactFRV1SOAP", host: "sii-proxy.gisce.net"
```

Readable mode:

`
2017/11/26 21:01:01 [error] 1439#1439: *260289 upstream timed out (110: Connection timed out) while reading response header from upstream, client: 192.168.32.23, server: , request: "POST /wlpl/SSII-FACT/ws/fr/SiiFactFRV1SOAP HTTP/1.1", upstream: "https://195.235.106.208:443/wlpl/SSII-FACT/ws/fr/SiiFactFRV1SOAP", host: "sii-proxy.gisce.net"
`
